### PR TITLE
Download data script

### DIFF
--- a/scripts/download_data.py
+++ b/scripts/download_data.py
@@ -17,10 +17,13 @@ def download_data(dataset, output_csv, output_zip):
     """Download dataset from Kaggle and save locally as CSV and ZIP."""
     
     path = kagglehub.dataset_download(dataset)
+
+    try:
+        df = pd.read_csv(os.path.join(path, "crime.csv"))
+    except Exception as e:
+        raise ValueError(f"File format issue: {e}")
     
-    
-    df = pd.read_csv(os.path.join(path, "crime.csv"))
-    
+        
     df.to_csv(output_csv, index=False)
     
     


### PR DESCRIPTION
Added a new script (download_data.py) that downloads the dataset from Kaggle, validates the CSV file, saves it locally, and outputs a zipped version.

To run the script, specify the Kaggle dataset identifier, the output CSV path, and the output ZIP path:
python download_data.py --dataset wosaku/crime-in-vancouver --output_csv data/crimedata.csv --output_zip data/crimedata.zip
